### PR TITLE
Pack tests as tools

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,6 +14,7 @@
     <OutputType>Exe</OutputType>
     <UseAppHost>true</UseAppHost>
     <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Avoid creating test packages that can't be executed.