### PR TITLE
Ensure SDK version can be overridden

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TestRoot Condition="'$(TestRoot)' == ''">$(ArtifactsObjDir)generatedtests/</TestRoot>
+    <TestSdkVersion Condition="'$(TestSdkVersion)' == ''">$(NETCoreSdkVersion)</TestSdkVersion>
   </PropertyGroup>
 
   <Target Name="CleanTestRoot">
@@ -46,11 +47,11 @@
     <PropertyGroup>
       <!-- Dotnet root typically ends in a \. Trim this to avoid issues with Exec -->
       <TestArgs>--dotnet-root "$(DotNetRoot.TrimEnd('\'))"</TestArgs>
-      <TestArgs>$(TestArgs) --sdk-version $(NETCoreSdkVersion)</TestArgs>
+      <TestArgs>$(TestArgs) --sdk-version $(TestSdkVersion)</TestArgs>
       <TestArgs>$(TestArgs) --test-root "$(TestRoot)"</TestArgs>
       <TestArgs>$(TestArgs) $(AdditionalTestArgs)</TestArgs>
 
-      <_MSBuildSdksDir>$(DotNetRoot)sdk/$(NETCoreSdkVersion)/Sdks</_MSBuildSdksDir>
+      <_MSBuildSdksDir>$(DotNetRoot)sdk/$(TestSdkVersion)/Sdks</_MSBuildSdksDir>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
When calling the `Test` target, the `NETCoreSdkVersion` property is used to configure the test environment. In some cases, it's not possible for the caller to override that value because it is hardcoded by https://github.com/dotnet/installer/blob/bf738fd99f28f1d6b80cc6af97253dc7acf00a46/src/redist/targets/GenerateBundledVersions.targets#L534. This can prevent the tests from working in the VMR environment.

This is resolved by introducing a new overridable property, `TestSdkVersion`, that will default to `NETCoreSdkVersion` if not overridden.