### PR TITLE
Increase timeout for web tests

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
@@ -177,7 +177,7 @@ internal class DotNetSdkHelper
             projectDirectory,
             additionalProcessConfigCallback: processConfigCallback,
             expectedExitCode: exitCode,
-            millisecondTimeout: 30000);
+            millisecondTimeout: 60000);
 
         void processConfigCallback(Process process)
         {


### PR DESCRIPTION
The web tests for F# occasionally timeout but often enough that it's becoming an issue. Increasing the timeout for all web tests to fix this.

Fixes https://github.com/dotnet/source-build/issues/4372