### PR TITLE
Disable WPF template test

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -84,7 +84,8 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
         newTest.Execute(_sdkHelper, _scenarioTestInput.TestRoot);
     }
     
-    [Theory]
+    // Disabled due to https://github.com/dotnet/source-build/issues/4361
+    //[Theory]
     [InlineData(DotNetLanguage.CSharp)]
     [InlineData(DotNetLanguage.VB)]
     [Trait("Category", "Offline")]


### PR DESCRIPTION
WPF test isn't reliable for VMR execution: https://github.com/dotnet/source-build/issues/4361