### PR TITLE
Disable validation stage in official builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,3 +105,8 @@ stages:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
+    parameters:
+      enableSymbolValidation: false
+      enableSigningValidation: false
+      enableNugetValidation: false
+      enableSourceLinkValidation: false


### PR DESCRIPTION
We don't need any of the post-build validation steps for scenario-tests. As those are failing the build since a few months, disable them.