### PR TITLE
Skip tests that require portable assets on community architectures.

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.Common/Program.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/Program.cs
@@ -249,6 +249,10 @@ namespace ScenarioTests
         {
             List<string> buildTraits = new();
 
+            int archSeparatorPos = targetRid.LastIndexOf('-');
+            string ridWithoutArch = targetRid.Substring(0, archSeparatorPos != -1 ? archSeparatorPos : 0);
+            string arch = targetRid.Substring(archSeparatorPos + 1);
+
             // Mono
             if (DetermineIsMonoRuntime(dotnetRoot))
             {
@@ -256,12 +260,17 @@ namespace ScenarioTests
             }
 
             // Portable
-            int archSeparatorPos = targetRid.LastIndexOf('-');
-            string ridWithoutArch = targetRid.Substring(0, archSeparatorPos != -1 ? archSeparatorPos : 0);
             string[] portableRids = [ "linux", "linux-musl" ];
             if (Array.IndexOf(portableRids, ridWithoutArch) != -1)
             {
                 buildTraits.Add("Portable");
+            }
+
+            // CommunityArchitecture
+            string[] communityArchitectures = [ "s390x", "ppc64le", "loongarch64", "riscv64" ];
+            if (Array.IndexOf(communityArchitectures, arch) != -1)
+            {
+                buildTraits.Add("CommunityArchitecture");
             }
 
             return buildTraits;

--- a/src/Microsoft.DotNet.ScenarioTests.Common/ScenarioTestFixture.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/ScenarioTestFixture.cs
@@ -39,4 +39,6 @@ public class ScenarioTestFixture
     public string DotNetRoot { get; set; }
     public string TestRoot { get; set; }
     public string TargetRid { get; set; }
+    public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
+    public string PortableRid { get => $"linux-{TargetArchitecture}"; }
 }

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotnetWorkloadTest.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotnetWorkloadTest.cs
@@ -10,7 +10,7 @@ internal class DotnetWorkloadTest
     public DotNetLanguage Language { get; }
     public bool NoHttps { get => TargetRid.Contains("osx"); }
     public string TargetRid { get; set; }
-    public string TargetArchitecture { get => TargetRid.Split('-')[1]; }
+    public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
     public string ScenarioName { get; }
 
     public DotnetWorkloadTest(string scenarioName, string targetRid,  DotNetSdkActions commands = DotNetSdkActions.None)

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTest.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTest.cs
@@ -10,7 +10,7 @@ public class SdkTemplateTest
     public DotNetLanguage Language { get; }
     public bool NoHttps { get => TargetRid.Contains("osx"); }
     public string TargetRid { get; set; }
-    public string TargetArchitecture { get => TargetRid.Split('-')[1]; }
+    public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
     public string ScenarioName { get; }
     public DotNetSdkTemplate Template { get; }
 
@@ -87,11 +87,10 @@ public class SdkTemplateTest
         {
             dotNetHelper.ExecutePublish(projectDirectory, selfContained: false);        
             dotNetHelper.ExecutePublish(projectDirectory, TargetRid, selfContained: true);
-            dotNetHelper.ExecutePublish(projectDirectory, $"linux-{TargetArchitecture}", selfContained: true);
         }
         if (Commands.HasFlag(DotNetSdkActions.PublishR2R))
         {
-            dotNetHelper.ExecutePublish(projectDirectory, $"linux-{TargetArchitecture}", selfContained: true, trimmed: true, readyToRun: true);
+            dotNetHelper.ExecutePublish(projectDirectory, TargetRid, selfContained: true, trimmed: true, readyToRun: true);
         }
         if (Commands.HasFlag(DotNetSdkActions.PublishAot))
         {

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -38,7 +38,7 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
     public void VerifyConsoleTemplateComplexPortable(DotNetLanguage language)
     {
         var newTest = new SdkTemplateTest(
-            nameof(SdkTemplateTests) + "Complex", language, _scenarioTestInput.PortableRid, DotNetSdkTemplate.Console,
+            nameof(SdkTemplateTests) + "ComplexPortable", language, _scenarioTestInput.PortableRid, DotNetSdkTemplate.Console,
             DotNetSdkActions.Build | DotNetSdkActions.Run | DotNetSdkActions.PublishComplex | DotNetSdkActions.PublishR2R);
         newTest.Execute(_sdkHelper, _scenarioTestInput.TestRoot);
     }

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -28,6 +28,17 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
     {
         var newTest = new SdkTemplateTest(
             nameof(SdkTemplateTests) + "Complex", language, _scenarioTestInput.TargetRid, DotNetSdkTemplate.Console,
+            DotNetSdkActions.Build | DotNetSdkActions.Run | DotNetSdkActions.PublishComplex);
+        newTest.Execute(_sdkHelper, _scenarioTestInput.TestRoot);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetLanguages))]
+    [Trait("SkipIfBuild", "CommunityArchitecture")] // Portable assets are not available for community architectures.
+    public void VerifyConsoleTemplateComplexPortable(DotNetLanguage language)
+    {
+        var newTest = new SdkTemplateTest(
+            nameof(SdkTemplateTests) + "Complex", language, _scenarioTestInput.PortableRid, DotNetSdkTemplate.Console,
             DotNetSdkActions.Build | DotNetSdkActions.Run | DotNetSdkActions.PublishComplex | DotNetSdkActions.PublishR2R);
         newTest.Execute(_sdkHelper, _scenarioTestInput.TestRoot);
     }
@@ -221,6 +232,7 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
 
     [Fact]
     [Trait("Category", "Workload")]
+    [Trait("SkipIfBuild", "CommunityArchitecture")]     // SDK has no workloads that support community architectures.
     public void VerifyWorkloadCmd()
     {
         var newTest = new DotnetWorkloadTest(


### PR DESCRIPTION
For community architectures, only non-portable assets are available.

@ViktorHofer @MichaelSimons ptal.

cc @omajid @Swapnali911