### PR TITLE
Revert "Disabling workload uninstall test to enable -rtm branded sdk"

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotnetWorkloadTest.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotnetWorkloadTest.cs
@@ -34,9 +34,8 @@ internal class DotnetWorkloadTest
             originalSource = dotNetHelper.ExecuteWorkloadList(projectDirectory, workloadID, false, firstRun: true);
             dotNetHelper.ExecuteWorkloadInstall(projectDirectory, workloadID);
             dotNetHelper.ExecuteWorkloadList(projectDirectory, workloadID, true, originalSource);
-            // Uninstall does not work on -rtm banded SDKs that are not stable. Additionally, uninstall is <.5% of usage of workload command so disabling for now
-            // dotNetHelper.ExecuteWorkloadUninstall(projectDirectory, workloadID);
-            // dotNetHelper.ExecuteWorkloadList(projectDirectory, workloadID, false, originalSource);
+            dotNetHelper.ExecuteWorkloadUninstall(projectDirectory, workloadID);
+            dotNetHelper.ExecuteWorkloadList(projectDirectory, workloadID, false, originalSource);
         }
         if (Commands.HasFlag(DotNetSdkActions.WorkloadInstall))
         {


### PR DESCRIPTION
Reverts dotnet/scenario-tests#114

https://github.com/dotnet/sdk/pull/43797 is merged so we can re-enable the uninstall which might help with https://github.com/dotnet/source-build/issues/4636