### PR TITLE
Backport #113 (NativeAOT test) and #108 (Skip on community architectures) to release/9.0.

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.Common/Program.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/Program.cs
@@ -156,7 +156,7 @@ namespace ScenarioTests
             discoverer.Find(false, discoverySink, TestFrameworkOptions.ForDiscovery(assemblyConfig));
             discoverySink.Finished.WaitOne();
 
-            XunitFilters filters = CreateFilters(noTraits, traits, offlineOnly, platform);
+            XunitFilters filters = CreateFilters(noTraits, traits, offlineOnly, platform, dotnetRoot, targetRid);
 
             var filteredTestCases = discoverySink.TestCases.Where(filters.Filter).ToList();
 
@@ -217,7 +217,7 @@ namespace ScenarioTests
         }
 
 
-        private static XunitFilters CreateFilters(IList<string> excludedTraits, IList<string> includedTraits, bool offlineOnly, OSPlatform platform)
+        private static XunitFilters CreateFilters(IList<string> excludedTraits, IList<string> includedTraits, bool offlineOnly, OSPlatform platform, string dotnetRoot, string targetRid)
         {
             XunitFilters filters = new XunitFilters();
 
@@ -234,6 +234,8 @@ namespace ScenarioTests
 
             filters.ExcludedTraits.Add("SkipIfPlatform", new List<string>() {$"{platform}"});
 
+            filters.ExcludedTraits.Add("SkipIfBuild", CreateBuildTraits(dotnetRoot, targetRid));
+
             Dictionary<string, List<string>> includedTraitsMap = ParseTraitKeyValuePairs(includedTraits);
             foreach (KeyValuePair<string, List<string>> kvp in includedTraitsMap)
             {
@@ -241,6 +243,48 @@ namespace ScenarioTests
             }
 
             return filters;
+        }
+
+        private static List<string> CreateBuildTraits(string dotnetRoot, string targetRid)
+        {
+            List<string> buildTraits = new();
+
+            // Mono
+            if (DetermineIsMonoRuntime(dotnetRoot))
+            {
+                buildTraits.Add("Mono");
+            }
+
+            // Portable
+            int archSeparatorPos = targetRid.LastIndexOf('-');
+            string ridWithoutArch = targetRid.Substring(0, archSeparatorPos != -1 ? archSeparatorPos : 0);
+            string[] portableRids = [ "linux", "linux-musl" ];
+            if (Array.IndexOf(portableRids, ridWithoutArch) != -1)
+            {
+                buildTraits.Add("Portable");
+            }
+
+            return buildTraits;
+        }
+
+        private static bool DetermineIsMonoRuntime(string dotnetRoot)
+        {
+            string sharedFrameworkRoot = Path.Combine(dotnetRoot, "shared", "Microsoft.NETCore.App");
+            if (!Directory.Exists(sharedFrameworkRoot))
+            {
+                return false;
+            }
+
+            string? version = Directory.GetDirectories(sharedFrameworkRoot).FirstOrDefault();
+            if (version is null)
+            {
+                return false;
+            }
+
+            string sharedFramework = Path.Combine(sharedFrameworkRoot, version);
+
+            // Check the presence of one of the mono header files.
+            return File.Exists(Path.Combine(sharedFramework, "mono-gc.h"));
         }
 
         private static Dictionary<string, List<string>> ParseTraitKeyValuePairs(IList<string> excludedTraits)

--- a/src/Microsoft.DotNet.ScenarioTests.Common/Program.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/Program.cs
@@ -249,6 +249,10 @@ namespace ScenarioTests
         {
             List<string> buildTraits = new();
 
+            int archSeparatorPos = targetRid.LastIndexOf('-');
+            string ridWithoutArch = targetRid.Substring(0, archSeparatorPos != -1 ? archSeparatorPos : 0);
+            string arch = targetRid.Substring(archSeparatorPos + 1);
+
             // Mono
             if (DetermineIsMonoRuntime(dotnetRoot))
             {
@@ -256,12 +260,17 @@ namespace ScenarioTests
             }
 
             // Portable
-            int archSeparatorPos = targetRid.LastIndexOf('-');
-            string ridWithoutArch = targetRid.Substring(0, archSeparatorPos != -1 ? archSeparatorPos : 0);
             string[] portableRids = [ "linux", "linux-musl" ];
             if (Array.IndexOf(portableRids, ridWithoutArch) != -1)
             {
                 buildTraits.Add("Portable");
+            }
+
+            // CommunityArchitecture
+            string[] communityArchitectures = [ "s390x", "ppc64le", "loongarch64", "riscv64" ];
+            if (Array.IndexOf(communityArchitectures, arch) != -1)
+            {
+                buildTraits.Add("CommunityArchitecture");
             }
 
             return buildTraits;

--- a/src/Microsoft.DotNet.ScenarioTests.Common/ScenarioTestFixture.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/ScenarioTestFixture.cs
@@ -39,4 +39,6 @@ public class ScenarioTestFixture
     public string DotNetRoot { get; set; }
     public string TestRoot { get; set; }
     public string TargetRid { get; set; }
+    public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
+    public string PortableRid { get => $"linux-{TargetArchitecture}"; }
 }

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkActions.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkActions.cs
@@ -14,9 +14,10 @@ public enum DotNetSdkActions
     Publish = 8,
     PublishComplex = 16,
     PublishR2R = 32,
-    Test = 64,
-    AddClassLibRef = 128,
-    FullWorkloadTest = 256,
-    WorkloadInstall = 512,
-    WorkloadUninstall = 1024,
+    PublishAot = 64,
+    Test = 128,
+    AddClassLibRef = 256,
+    FullWorkloadTest = 512,
+    WorkloadInstall = 1024,
+    WorkloadUninstall = 2048
 }

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
@@ -17,7 +17,6 @@ internal class DotNetSdkHelper
     public string? SdkVersion { get; set; }
     public string DotNetExecutablePath { get =>
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Path.Combine(DotNetRoot, "dotnet.exe") : Path.Combine(DotNetRoot, "dotnet"); }
-
     private ITestOutputHelper OutputHelper { get; }
 
     public DotNetSdkHelper(ITestOutputHelper outputHelper, string dotnetRoot, string? sdkVersion)
@@ -105,7 +104,7 @@ internal class DotNetSdkHelper
         return projectDirectory;
     }
 
-    public void ExecutePublish(string projectDirectory, bool? selfContained = null, string? rid = null, bool trimmed = false, bool readyToRun = false, string[]? frameworks = null)
+    public void ExecutePublish(string projectDirectory, string? rid = null, bool? selfContained = null, bool trimmed = false, bool readyToRun = false, bool? aot = false, string[]? frameworks = null)
     {
         string options = string.Empty;
         string binlogDifferentiator = string.Empty;
@@ -131,6 +130,15 @@ internal class DotNetSdkHelper
                     options += " /p:PublishReadyToRun=true";
                     binlogDifferentiator += "-R2R";
                 }
+            }
+        }
+
+        if (aot.HasValue)
+        {
+            options += $" /p:PublishAot={aot.Value.ToString().ToLowerInvariant()}";
+            if (aot.Value)
+            {
+                binlogDifferentiator += "-aot";
             }
         }
 

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotnetWorkloadTest.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotnetWorkloadTest.cs
@@ -10,7 +10,7 @@ internal class DotnetWorkloadTest
     public DotNetLanguage Language { get; }
     public bool NoHttps { get => TargetRid.Contains("osx"); }
     public string TargetRid { get; set; }
-    public string TargetArchitecture { get => TargetRid.Split('-')[1]; }
+    public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
     public string ScenarioName { get; }
 
     public DotnetWorkloadTest(string scenarioName, string targetRid,  DotNetSdkActions commands = DotNetSdkActions.None)

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTest.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTest.cs
@@ -86,12 +86,16 @@ public class SdkTemplateTest
         if (Commands.HasFlag(DotNetSdkActions.PublishComplex))
         {
             dotNetHelper.ExecutePublish(projectDirectory, selfContained: false);        
-            dotNetHelper.ExecutePublish(projectDirectory, selfContained: true, TargetRid);
-            dotNetHelper.ExecutePublish(projectDirectory, selfContained: true, $"linux-{TargetArchitecture}");
+            dotNetHelper.ExecutePublish(projectDirectory, TargetRid, selfContained: true);
+            dotNetHelper.ExecutePublish(projectDirectory, $"linux-{TargetArchitecture}", selfContained: true);
         }
         if (Commands.HasFlag(DotNetSdkActions.PublishR2R))
         {
-            dotNetHelper.ExecutePublish(projectDirectory, selfContained: true, $"linux-{TargetArchitecture}", trimmed: true, readyToRun: true);
+            dotNetHelper.ExecutePublish(projectDirectory, $"linux-{TargetArchitecture}", selfContained: true, trimmed: true, readyToRun: true);
+        }
+        if (Commands.HasFlag(DotNetSdkActions.PublishAot))
+        {
+            dotNetHelper.ExecutePublish(projectDirectory, TargetRid, aot: true);
         }
         if (Commands.HasFlag(DotNetSdkActions.Test))
         {

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTest.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTest.cs
@@ -10,7 +10,7 @@ public class SdkTemplateTest
     public DotNetLanguage Language { get; }
     public bool NoHttps { get => TargetRid.Contains("osx"); }
     public string TargetRid { get; set; }
-    public string TargetArchitecture { get => TargetRid.Split('-')[1]; }
+    public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
     public string ScenarioName { get; }
     public DotNetSdkTemplate Template { get; }
 
@@ -87,11 +87,10 @@ public class SdkTemplateTest
         {
             dotNetHelper.ExecutePublish(projectDirectory, selfContained: false);        
             dotNetHelper.ExecutePublish(projectDirectory, TargetRid, selfContained: true);
-            dotNetHelper.ExecutePublish(projectDirectory, $"linux-{TargetArchitecture}", selfContained: true);
         }
         if (Commands.HasFlag(DotNetSdkActions.PublishR2R))
         {
-            dotNetHelper.ExecutePublish(projectDirectory, $"linux-{TargetArchitecture}", selfContained: true, trimmed: true, readyToRun: true);
+            dotNetHelper.ExecutePublish(projectDirectory, TargetRid, selfContained: true, trimmed: true, readyToRun: true);
         }
         if (Commands.HasFlag(DotNetSdkActions.PublishAot))
         {

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -28,6 +28,17 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
     {
         var newTest = new SdkTemplateTest(
             nameof(SdkTemplateTests) + "Complex", language, _scenarioTestInput.TargetRid, DotNetSdkTemplate.Console,
+            DotNetSdkActions.Build | DotNetSdkActions.Run | DotNetSdkActions.PublishComplex);
+        newTest.Execute(_sdkHelper, _scenarioTestInput.TestRoot);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetLanguages))]
+    [Trait("SkipIfBuild", "CommunityArchitecture")] // Portable assets are not available for community architectures.
+    public void VerifyConsoleTemplateComplexPortable(DotNetLanguage language)
+    {
+        var newTest = new SdkTemplateTest(
+            nameof(SdkTemplateTests) + "ComplexPortable", language, _scenarioTestInput.PortableRid, DotNetSdkTemplate.Console,
             DotNetSdkActions.Build | DotNetSdkActions.Run | DotNetSdkActions.PublishComplex | DotNetSdkActions.PublishR2R);
         newTest.Execute(_sdkHelper, _scenarioTestInput.TestRoot);
     }
@@ -221,6 +232,7 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
 
     [Fact]
     [Trait("Category", "Workload")]
+    [Trait("SkipIfBuild", "CommunityArchitecture")]     // SDK has no workloads that support community architectures.
     public void VerifyWorkloadCmd()
     {
         var newTest = new DotnetWorkloadTest(

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -209,6 +209,17 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
     }
 
     [Fact]
+    [Trait("SkipIfBuild", "Portable")] // Portable builds don't bundle an AOT compiler.
+    [Trait("SkipIfBuild", "Mono")]     // Mono builds don't bundle an AOT compiler.
+    public void VerifyWebTemplatePublishBundledAot()
+    {
+        var newTest = new SdkTemplateTest(
+            nameof(SdkTemplateTests) + "Aot", DotNetLanguage.CSharp, _scenarioTestInput.TargetRid, DotNetSdkTemplate.Web,
+            DotNetSdkActions.PublishAot);
+        newTest.Execute(_sdkHelper, _scenarioTestInput.TestRoot);
+    }
+
+    [Fact]
     [Trait("Category", "Workload")]
     public void VerifyWorkloadCmd()
     {


### PR DESCRIPTION
Backports:
- https://github.com/dotnet/scenario-tests/pull/108
- https://github.com/dotnet/scenario-tests/pull/113

@mthalman ptal.