### PR TITLE
Add roll forward switch to scenario-tests

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,6 +15,8 @@
     <UseAppHost>true</UseAppHost>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
+    <!-- Allow test apps to be invoked with a newer SDK. -->
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Allows re-enabling the scenario-tests in the VMR without re-targeting the tests to net10.0. Needed for https://github.com/dotnet/sdk/pull/44937