### PR TITLE
Disable workload tests that pick up global state

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -230,6 +230,7 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
         newTest.Execute(_sdkHelper, _scenarioTestInput.TestRoot);
     }
 
+    [Fact(Skip = "https://github.com/dotnet/scenario-tests/issues/132")]
     [Fact]
     [Trait("Category", "Workload")]
     [Trait("SkipIfBuild", "CommunityArchitecture")]     // SDK has no workloads that support community architectures.


### PR DESCRIPTION
Global (VS) state is picked up. And these tests are kinda problematic since they're altering the state of the SDK under test by other tests running at the same time.