### PR TITLE
Skip second darc publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,3 +120,4 @@ stages:
       enableSigningValidation: false
       enableNugetValidation: false
       enableSourceLinkValidation: false
+      publishAssetsImmediately: true


### PR DESCRIPTION
We use `publishAssetsImmediately: true`  during the main job