### PR TITLE
Retry AddressInUseException during web scenarios

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.Common/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/ExecuteHelper.cs
@@ -103,7 +103,13 @@ public static class ExecuteHelper
                 $"{Environment.NewLine}Exit code: {result.Process.ExitCode}" +
                 $"{Environment.NewLine}{result.StdOut}" +
                 $"{Environment.NewLine}{result.StdErr}";
-            throw new InvalidOperationException(msg);
+
+            var ex = new InvalidOperationException(msg);
+            if (result.StdErr.Contains("Microsoft.AspNetCore.Connections.AddressInUseException"))
+            {
+                ex.Data["IsAddressInUseException"] = true;
+            }
+            throw ex;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/scenario-tests/issues/96

I tested this locally by stepping through the tests and opening the port in the generated project's launchSettings.json and observing that it correctly does the retry and generates a new project with a new port.