### PR TITLE
Terminate child processes in ExecuteRunWeb too

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
@@ -195,7 +195,7 @@ internal class DotNetSdkHelper
             {
                 if (e.Data?.Contains("Application started. Press Ctrl+C to shut down.") ?? false)
                 {
-                    process.Kill();
+                    process.Kill(true);
                     process.WaitForExit();
                 }
             });


### PR DESCRIPTION
While looking at https://github.com/dotnet/source-build/issues/4775 I noticed that we were leaving behind a lot of processes related to the web tests. This is because we were only killing the "dotnet run" process but that didn't terminate the child process with the actual web app.