### PR TITLE
Ensure RID option is set for AOT publish scenario

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
@@ -110,18 +110,19 @@ internal class DotNetSdkHelper
     {
         string options = string.Empty;
         string binlogDifferentiator = string.Empty;
+
+        if (!string.IsNullOrEmpty(rid))
+        {
+            options += $" -r {rid}";
+            binlogDifferentiator += $"-{rid}";
+        }
         
         if (selfContained.HasValue)
         {
-            options += $"--self-contained {selfContained.Value.ToString().ToLowerInvariant()}";
+            options += $" --self-contained {selfContained.Value.ToString().ToLowerInvariant()}";
             if (selfContained.Value)
             {
                 binlogDifferentiator += "self-contained";
-                if (!string.IsNullOrEmpty(rid))
-                {
-                    options += $" -r {rid}";
-                    binlogDifferentiator += $"-{rid}";
-                }
                 if (trimmed)
                 {
                     options += " /p:PublishTrimmed=true";


### PR DESCRIPTION
When running the [Native AOT publish test](https://github.com/dotnet/scenario-tests/blob/338a5ed76d040627c6de30bf877c071ca303c193/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs#L225), it doesn't end up setting the RID when calling `dotnet publish`. This leads to the issue described in https://github.com/dotnet/sdk/pull/46215#issuecomment-2610293316.

This updates the test infrastructure to set the RID on the `dotnet publish` command when it is provided, so by default it will include it for the Native AOT test.

cc @tmds 