### PR TITLE
Respect portable RID passed in via CLI or env var

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.Common/Program.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/Program.cs
@@ -77,6 +77,11 @@ namespace ScenarioTests
                 DefaultValueFactory = (_) => RuntimeInformation.RuntimeIdentifier
             };
 
+            CliOption<string> portableRidOption = new("--portable-rid")
+            {
+                Description = "Portable rid for tests requiring one (e.g. self-contained publish).",
+            };
+
             rootCommand.Options.Add(dotnetRootOption);
             rootCommand.Options.Add(testRootOption);
             rootCommand.Options.Add(sdkVersionOption);
@@ -87,6 +92,7 @@ namespace ScenarioTests
             rootCommand.Options.Add(xmlResultsPathOption);
             rootCommand.Options.Add(noCleanTestRoot);
             rootCommand.Options.Add(targetRidOption);
+            rootCommand.Options.Add(portableRidOption);
 
 
             rootCommand.SetAction((ParseResult parseResult) =>
@@ -95,6 +101,7 @@ namespace ScenarioTests
                        parseResult.GetValue(testRootOption)!,
                        parseResult.GetValue(sdkVersionOption),
                        parseResult.GetValue(targetRidOption)!,
+                       parseResult.GetValue(portableRidOption),
                        parseResult.GetValue(listTestsOption),
                        parseResult.GetValue(offlineOnlyOption),
                        parseResult.GetValue(noTraitsOption) ?? (IList<string>)ImmutableList<string>.Empty,
@@ -110,6 +117,7 @@ namespace ScenarioTests
                                  string testRoot,
                                  string? sdkVersion,
                                  string targetRid,
+                                 string? portableRid,
                                  bool listOnly,
                                  bool offlineOnly,
                                  IList<string> noTraits,
@@ -168,6 +176,7 @@ namespace ScenarioTests
             Console.WriteLine($"  Dotnet Root: {dotnetRoot}");
             Console.WriteLine($"  Test root: {testRoot}");
             Console.WriteLine($"  Target RID: {targetRid}");
+            Console.WriteLine($"  Portable RID: {portableRid}");
             Console.WriteLine($"  Sdk Version: {sdkVersion ?? "latest"}");
             Console.WriteLine($"  Platform: {platform}");
 
@@ -186,7 +195,7 @@ namespace ScenarioTests
                 return 0;
             }
 
-            SetupTestEnvironment(dotnetRoot, testRoot, sdkVersion, targetRid);
+            SetupTestEnvironment(dotnetRoot, testRoot, sdkVersion, targetRid, portableRid);
 
             var executor = xunitTestFx.CreateExecutor(asmName);
             executor.RunTests(filteredTestCases, resultsSink, TestFrameworkOptions.ForExecution(assemblyConfig));
@@ -207,7 +216,7 @@ namespace ScenarioTests
             return failed ? 1 : 0;
         }
 
-        private static void SetupTestEnvironment(string dotnetRoot, string testRoot, string? sdkVersion, string targetRid)
+        private static void SetupTestEnvironment(string dotnetRoot, string testRoot, string? sdkVersion, string targetRid, string? portableRid)
         {
             // Verify that the input parameters 
             // Create any directories as necessary
@@ -218,6 +227,7 @@ namespace ScenarioTests
             Environment.SetEnvironmentVariable(ScenarioTestFixture.TestRootEnvironmentVariable, testRoot);
             Environment.SetEnvironmentVariable(ScenarioTestFixture.SdkVersionEnvironmentVariable, sdkVersion);
             Environment.SetEnvironmentVariable(ScenarioTestFixture.TargetRidEnvironmentVariable, targetRid);
+            Environment.SetEnvironmentVariable(ScenarioTestFixture.PortableRidEnvironmentVariable, portableRid);
         }
 
 

--- a/src/Microsoft.DotNet.ScenarioTests.Common/ScenarioTestFixture.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/ScenarioTestFixture.cs
@@ -16,6 +16,7 @@ public class ScenarioTestFixture
     public const string SdkVersionEnvironmentVariable = "SCENARIO_TESTS_SDKVERSION";
     public const string TestRootEnvironmentVariable = "SCENARIO_TESTS_TESTROOT";
     public const string TargetRidEnvironmentVariable = "SCENARIO_TESTS_TARGETRID";
+    public const string PortableRidEnvironmentVariable = "SCENARIO_TESTS_PORTABLERID";
 
     public ScenarioTestFixture()
     {
@@ -23,6 +24,7 @@ public class ScenarioTestFixture
         string? testRoot = Environment.GetEnvironmentVariable(TestRootEnvironmentVariable);
         string? sdkVersion = Environment.GetEnvironmentVariable(SdkVersionEnvironmentVariable);
         string? targetRid = Environment.GetEnvironmentVariable(TargetRidEnvironmentVariable);
+        string? portableRid = Environment.GetEnvironmentVariable(PortableRidEnvironmentVariable);
 
         if (string.IsNullOrEmpty(dotnetRoot) || string.IsNullOrEmpty(testRoot) || string.IsNullOrEmpty(targetRid))
         {
@@ -33,6 +35,7 @@ public class ScenarioTestFixture
         DotNetRoot = dotnetRoot;
         TestRoot = testRoot;
         TargetRid = targetRid;
+        PortableRid = portableRid;
     }
 
     public string? SdkVersion { get; internal set; }
@@ -40,5 +43,5 @@ public class ScenarioTestFixture
     public string TestRoot { get; set; }
     public string TargetRid { get; set; }
     public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
-    public string PortableRid { get => $"linux-{TargetArchitecture}"; }
+    public string? PortableRid { get; set; }
 }

--- a/src/Microsoft.DotNet.ScenarioTests.Common/ScenarioTestFixture.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/ScenarioTestFixture.cs
@@ -42,6 +42,6 @@ public class ScenarioTestFixture
     public string DotNetRoot { get; set; }
     public string TestRoot { get; set; }
     public string TargetRid { get; set; }
-    public string TargetArchitecture { get => TargetRid!.Split('-').Last(); }
+    public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
     public string? PortableRid { get; set; }
 }

--- a/src/Microsoft.DotNet.ScenarioTests.Common/ScenarioTestFixture.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/ScenarioTestFixture.cs
@@ -42,6 +42,6 @@ public class ScenarioTestFixture
     public string DotNetRoot { get; set; }
     public string TestRoot { get; set; }
     public string TargetRid { get; set; }
-    public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
+    public string TargetArchitecture { get => TargetRid!.Split('-').Last(); }
     public string? PortableRid { get; set; }
 }

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotnetWorkloadTest.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotnetWorkloadTest.cs
@@ -13,7 +13,7 @@ internal class DotnetWorkloadTest
     public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
     public string ScenarioName { get; }
 
-    public DotnetWorkloadTest(string scenarioName, string targetRid,  DotNetSdkActions commands = DotNetSdkActions.None)
+    public DotnetWorkloadTest(string scenarioName, string targetRid, DotNetSdkActions commands = DotNetSdkActions.None)
     {
         ScenarioName = scenarioName;
         Commands = commands;

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTest.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTest.cs
@@ -7,11 +7,17 @@ namespace Microsoft.DotNet.ScenarioTests.SdkTemplateTests;
 public class SdkTemplateTest
 {
     public DotNetSdkActions Commands { get; }
+
     public DotNetLanguage Language { get; }
+
     public bool NoHttps { get => TargetRid.Contains("osx"); }
+
     public string TargetRid { get; set; }
+
     public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
+
     public string ScenarioName { get; }
+
     public DotNetSdkTemplate Template { get; }
 
     public SdkTemplateTest(string scenarioName, DotNetLanguage language, string targetRid, DotNetSdkTemplate template, DotNetSdkActions commands = DotNetSdkActions.None)

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -37,7 +37,7 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
     [Trait("SkipIfBuild", "CommunityArchitecture")] // Portable assets are not available for community architectures.
     public void VerifyConsoleTemplateComplexPortable(DotNetLanguage language)
     {
-        string portableRid = _scenarioTestInput.PortableRid ?? $"linux-{_scenarioTestInput.TargetArchitecture}";
+        string portableRid = _scenarioTestInput.PortableRid ?? $"linux-{_scenarioTestInput.TargetArchitecture!}";
 
         var newTest = new SdkTemplateTest(
             nameof(SdkTemplateTests) + "ComplexPortable", language, _scenarioTestInput.PortableRid, DotNetSdkTemplate.Console,

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -37,11 +37,7 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
     [Trait("SkipIfBuild", "CommunityArchitecture")] // Portable assets are not available for community architectures.
     public void VerifyConsoleTemplateComplexPortable(DotNetLanguage language)
     {
-        // Skip if a portable RID isn't provided.
-        if (_scenarioTestInput.PortableRid is null)
-        {
-            return;
-        }
+        string portableRid = _scenarioTestInput.PortableRid ?? $"linux-{_scenarioTestInput.TargetArchitecture}";
 
         var newTest = new SdkTemplateTest(
             nameof(SdkTemplateTests) + "ComplexPortable", language, _scenarioTestInput.PortableRid, DotNetSdkTemplate.Console,

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -37,6 +37,9 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
     [Trait("SkipIfBuild", "CommunityArchitecture")] // Portable assets are not available for community architectures.
     public void VerifyConsoleTemplateComplexPortable(DotNetLanguage language)
     {
+        // This uses the wrong portable RID for non linux platforms when running the tests without supplying
+        // a portable RID. The VMR will supply one so the incorrectness applies to the test execution inside the
+        // scenario-tests repository only.
         string portableRid = _scenarioTestInput.PortableRid ?? $"linux-{_scenarioTestInput.TargetArchitecture}";
 
         var newTest = new SdkTemplateTest(

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.DotNet.ScenarioTests.Common;
+using Microsoft.DotNet.ScenarioTests.Common;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -39,7 +39,8 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
     {
         // This uses the wrong portable RID for non linux platforms when running the tests without supplying
         // a portable RID. The VMR will supply one so the incorrectness applies to the test execution inside the
-        // scenario-tests repository only.
+        // scenario-tests repository only. https://github.com/dotnet/scenario-tests/issues/190 tracks removing this
+        // default.
         string portableRid = _scenarioTestInput.PortableRid ?? $"linux-{_scenarioTestInput.TargetArchitecture}";
 
         var newTest = new SdkTemplateTest(

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -37,7 +37,7 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
     [Trait("SkipIfBuild", "CommunityArchitecture")] // Portable assets are not available for community architectures.
     public void VerifyConsoleTemplateComplexPortable(DotNetLanguage language)
     {
-        string portableRid = _scenarioTestInput.PortableRid ?? $"linux-{_scenarioTestInput.TargetArchitecture!}";
+        string portableRid = _scenarioTestInput.PortableRid ?? $"linux-{_scenarioTestInput.TargetArchitecture}";
 
         var newTest = new SdkTemplateTest(
             nameof(SdkTemplateTests) + "ComplexPortable", language, _scenarioTestInput.PortableRid, DotNetSdkTemplate.Console,

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -43,7 +43,7 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
         string portableRid = _scenarioTestInput.PortableRid ?? $"linux-{_scenarioTestInput.TargetArchitecture}";
 
         var newTest = new SdkTemplateTest(
-            nameof(SdkTemplateTests) + "ComplexPortable", language, _scenarioTestInput.PortableRid, DotNetSdkTemplate.Console,
+            nameof(SdkTemplateTests) + "ComplexPortable", language, portableRid, DotNetSdkTemplate.Console,
             DotNetSdkActions.Build | DotNetSdkActions.Run | DotNetSdkActions.PublishComplex | DotNetSdkActions.PublishR2R);
         newTest.Execute(_sdkHelper, _scenarioTestInput.TestRoot);
     }

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -37,6 +37,12 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
     [Trait("SkipIfBuild", "CommunityArchitecture")] // Portable assets are not available for community architectures.
     public void VerifyConsoleTemplateComplexPortable(DotNetLanguage language)
     {
+        // Skip if a portable RID isn't provided.
+        if (_scenarioTestInput.PortableRid is null)
+        {
+            return;
+        }
+
         var newTest = new SdkTemplateTest(
             nameof(SdkTemplateTests) + "ComplexPortable", language, _scenarioTestInput.PortableRid, DotNetSdkTemplate.Console,
             DotNetSdkActions.Build | DotNetSdkActions.Run | DotNetSdkActions.PublishComplex | DotNetSdkActions.PublishR2R);


### PR DESCRIPTION
Fixes https://github.com/dotnet/scenario-tests/issues/187
Partially unblocks https://github.com/dotnet/sdk/pull/46244

We will need to update this line in the VMR to pass the portableRid in: https://github.com/dotnet/sdk/blob/5aa4f469217ad30fa471dd36dd717fb305fb2084/src/SourceBuild/content/repo-projects/scenario-tests.proj#L39