### PR TITLE
Add binlog switch that allows to put binlogs into a specific folder

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -46,11 +46,10 @@
   <Target Name="Test"
           DependsOnTargets="CleanTestRoot;CreateDirectoryBuildFiles">
     <PropertyGroup>
-      <!-- Dotnet root typically ends in a \. Trim this to avoid issues with Exec -->
       <TestArgs>--dotnet-root "$(DotNetRoot.TrimEnd('\'))"</TestArgs>
       <TestArgs>$(TestArgs) --sdk-version $(TestSdkVersion)</TestArgs>
-      <TestArgs>$(TestArgs) --test-root "$(TestRoot)"</TestArgs>
-      <TestArgs>$(TestArgs) --binlog-dir "$(TestBinlogDir)"</TestArgs>
+      <TestArgs>$(TestArgs) --test-root "$(TestRoot.TrimEnd('\'))"</TestArgs>
+      <TestArgs>$(TestArgs) --binlog-dir "$(TestBinlogDir.TrimEnd('\'))"</TestArgs>
       <TestArgs>$(TestArgs) $(AdditionalTestArgs)</TestArgs>
 
       <_MSBuildSdksDir>$(DotNetRoot)sdk/$(TestSdkVersion)/Sdks</_MSBuildSdksDir>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TestRoot Condition="'$(TestRoot)' == ''">$(ArtifactsObjDir)generatedtests/</TestRoot>
     <TestSdkVersion Condition="'$(TestSdkVersion)' == ''">$(NETCoreSdkVersion)</TestSdkVersion>
+    <TestBinlogDir Condition="'$(TestBinlogDir)' == ''">$(ArtifactsTestResultsDir)</TestBinlogDir>
   </PropertyGroup>
 
   <Target Name="CleanTestRoot">
@@ -49,6 +50,7 @@
       <TestArgs>--dotnet-root "$(DotNetRoot.TrimEnd('\'))"</TestArgs>
       <TestArgs>$(TestArgs) --sdk-version $(TestSdkVersion)</TestArgs>
       <TestArgs>$(TestArgs) --test-root "$(TestRoot)"</TestArgs>
+      <TestArgs>$(TestArgs) --binlog-dir "$(TestBinlogDir)"</TestArgs>
       <TestArgs>$(TestArgs) $(AdditionalTestArgs)</TestArgs>
 
       <_MSBuildSdksDir>$(DotNetRoot)sdk/$(TestSdkVersion)/Sdks</_MSBuildSdksDir>

--- a/src/Microsoft.DotNet.ScenarioTests.Common/ScenarioTestFixture.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/ScenarioTestFixture.cs
@@ -17,6 +17,21 @@ public class ScenarioTestFixture
     public const string TestRootEnvironmentVariable = "SCENARIO_TESTS_TESTROOT";
     public const string TargetRidEnvironmentVariable = "SCENARIO_TESTS_TARGETRID";
     public const string PortableRidEnvironmentVariable = "SCENARIO_TESTS_PORTABLERID";
+    public const string BinlogDirEnvironmentVariable = "SCENARIO_TESTS_BINLOG_DIR";
+
+    public string? SdkVersion { get; }
+
+    public string DotNetRoot { get; }
+
+    public string TestRoot { get; }
+
+    public string TargetRid { get; }
+
+    public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
+
+    public string? PortableRid { get; }
+
+    public string? BinlogDir { get; }
 
     public ScenarioTestFixture()
     {
@@ -25,10 +40,11 @@ public class ScenarioTestFixture
         string? sdkVersion = Environment.GetEnvironmentVariable(SdkVersionEnvironmentVariable);
         string? targetRid = Environment.GetEnvironmentVariable(TargetRidEnvironmentVariable);
         string? portableRid = Environment.GetEnvironmentVariable(PortableRidEnvironmentVariable);
+        string? binlogDir = Environment.GetEnvironmentVariable(BinlogDirEnvironmentVariable);
 
         if (string.IsNullOrEmpty(dotnetRoot) || string.IsNullOrEmpty(testRoot) || string.IsNullOrEmpty(targetRid))
         {
-            throw new ArgumentException("Please specify SDK root,Test Root, and Target Rid");
+            throw new ArgumentException("Please specify SDK root,Test Root and Target Rid");
         }
 
         SdkVersion = sdkVersion;
@@ -36,12 +52,6 @@ public class ScenarioTestFixture
         TestRoot = testRoot;
         TargetRid = targetRid;
         PortableRid = portableRid;
+        BinlogDir = binlogDir;
     }
-
-    public string? SdkVersion { get; internal set; }
-    public string DotNetRoot { get; set; }
-    public string TestRoot { get; set; }
-    public string TargetRid { get; set; }
-    public string TargetArchitecture { get => TargetRid.Split('-').Last(); }
-    public string? PortableRid { get; set; }
 }

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -6,9 +6,8 @@ namespace Microsoft.DotNet.ScenarioTests.SdkTemplateTests;
 
 public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
 {
-    ScenarioTestFixture _scenarioTestInput;
-    ITestOutputHelper _testOutputHelper;
-    DotNetSdkHelper _sdkHelper;
+    private readonly ScenarioTestFixture _scenarioTestInput;
+    private readonly DotNetSdkHelper _sdkHelper;
 
     public SdkTemplateTests(ScenarioTestFixture testInput, ITestOutputHelper outputHelper)
     {
@@ -18,8 +17,7 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
         }
 
         _scenarioTestInput = testInput;
-        _testOutputHelper = outputHelper;
-        _sdkHelper = new DotNetSdkHelper(outputHelper, _scenarioTestInput.DotNetRoot, _scenarioTestInput.SdkVersion);
+        _sdkHelper = new DotNetSdkHelper(outputHelper, _scenarioTestInput.DotNetRoot, _scenarioTestInput.SdkVersion, _scenarioTestInput.BinlogDir);
     }
     
     [Theory]


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4849

This needs a reaction in the VMR orchestrator post merge.