### PR TITLE
Revert "update System.CommandLine"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,14 +3,14 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.25072.1">
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.23307.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>060374e56c1b2e741b6525ca8417006efb54fbd7</Sha>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.607201">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.430701">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>060374e56c1b2e741b6525ca8417006efb54fbd7</Sha>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
       <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25105.3">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,6 +4,6 @@
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
   <PropertyGroup>
-    <SystemCommandLineVersion>2.0.0-beta4.25072.1</SystemCommandLineVersion>
+    <SystemCommandLineVersion>2.0.0-beta4.23307.1</SystemCommandLineVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.ScenarioTests.Common/Program.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/Program.cs
@@ -20,39 +20,39 @@ namespace ScenarioTests
 
         public static async Task<int> Main(string[] args)
         {
-            var rootCommand = new RootCommand("Scenario test runner");
+            var rootCommand = new CliRootCommand("Scenario test runner");
 
-            Option<bool> listTestsOption = new("--list")
+            CliOption<bool> listTestsOption = new("--list")
             {
                 Description = "List tests that would be run, without running them."
             };
-            Option<List<string>> noTraitsOption = new("--no-traits")
+            CliOption<List<string>> noTraitsOption = new("--no-traits")
             {
                 Description = "Do not run tests with the following traits. Format X=Y"
             };
-            Option<List<string>> traitsOption = new("--traits")
+            CliOption<List<string>> traitsOption = new("--traits")
             {
                 Description = "Only run tests with the following traits. Format X=Y"
             };
-            Option<bool> offlineOnlyOption = new("--offline-only")
+            CliOption<bool> offlineOnlyOption = new("--offline-only")
             {
                 Description = "Only run tests that can be run in offline mode. Implies --notraits 'resources=online'"
             };
-            Option<string> xmlResultsPathOption = new("--xml")
+            CliOption<string> xmlResultsPathOption = new("--xml")
             {
                 Description = "XML result file."
             };
-            Option<string> testRootOption = new("--test-root")
+            CliOption<string> testRootOption = new("--test-root")
             {
                 DefaultValueFactory = (_) => Directory.CreateTempSubdirectory().FullName,
                 Description = "Directory used for temporary files when running tests"
             };
-            Option<bool> noCleanTestRoot = new("--no-cleanup")
+            CliOption<bool> noCleanTestRoot = new("--no-cleanup")
             {
                 Description = "Do not cleanup the test root after execution."
             };
 
-            Option<string> dotnetRootOption = new("--dotnet-root")
+            CliOption<string> dotnetRootOption = new("--dotnet-root")
             {
                 Description = "dotnet root to run tests against.",
                 Required = true
@@ -66,23 +66,23 @@ namespace ScenarioTests
                 }
             });
 
-            Option<string> sdkVersionOption = new("--sdk-version")
+            CliOption<string> sdkVersionOption = new("--sdk-version")
             {
                 Description = "Version of SDK to use to run tests against. Optional. Otherwise uses the default SDK at the dotnet root."
             };
 
-            Option<string> targetRidOption = new("--target-rid")
+            CliOption<string> targetRidOption = new("--target-rid")
             {
                 Description = "Target rid for tests requiring one (e.g. self-contained publish). If omitted, uses the target rid of the executing application",
                 DefaultValueFactory = (_) => RuntimeInformation.RuntimeIdentifier
             };
 
-            Option<string> portableRidOption = new("--portable-rid")
+            CliOption<string> portableRidOption = new("--portable-rid")
             {
                 Description = "Portable rid for tests requiring one (e.g. self-contained publish)."
             };
 
-            Option<string> binlogDirOption = new("--binlog-dir")
+            CliOption<string> binlogDirOption = new("--binlog-dir")
             {
                 Description = "Directory to store binlogs in. If omitted, binlogs are stored in the generated projecgt directory."
             };


### PR DESCRIPTION
Reverts dotnet/scenario-tests#199 due to circular dependency between SDK and NuGet.Client that both use System.CommandLine. The update will be re-introduced around April.

cc @ViktorHofer @akoeplinger 
