### PR TITLE
Drop support for prebuilt free local source-build

### DIFF
--- a/azure-pipelines-pr-ci.yml
+++ b/azure-pipelines-pr-ci.yml
@@ -34,7 +34,6 @@ stages:
       enablePublishTestResults: true
       enablePublishUsingPipelines: true
       enableTelemetry: true
-      enableSourceBuild: true
       publishAssetsImmediately: true
       helixRepo: dotnet/scenario-tests
       jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,6 @@ extends:
           enablePublishTestResults: true
           enablePublishUsingPipelines: true
           enableTelemetry: true
-          enableSourceBuild: true
           publishAssetsImmediately: true
           helixRepo: dotnet/scenario-tests
           jobs:

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,4 +1,0 @@
-<UsageData>
-  <IgnorePatterns>
-  </IgnorePatterns>
-</UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,33 +7,9 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
     </Dependency>
-    <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.430701">
-      <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
-      <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25106.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>91630b31ce859c28f637b62b566ea8829b982f2c</Sha>
-    </Dependency>
-    <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="10.0.0-beta.25106.4">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>91630b31ce859c28f637b62b566ea8829b982f2c</Sha>
-      <SourceBuild RepoName="arcade" ManagedOnly="true" />
-    </Dependency>
-    <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="10.0.610402">
-      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>81b495268ffb3f5cffbe63724ad085f831bcc1b1</Sha>
-      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
-    </Dependency>
-    <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="10.0.610402">
-      <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>2915d1c17a406e42d6cfd68235c863313e9d7467</Sha>
-      <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
Drop support for building source build prebuilt clean within the repo.  The reason this is being dropped is described in [Repository and VMR PR/CI validation Strategy](https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Repo-and-VMR-Validation.md)

1. Remove the source build legs from pr/ci
2. Remove the intermediate dependencies from Version.Details.xml
3. Remove the SourceBuildPrebuiltBaseline.xml file

I will remove the darc subscriptions for SBE and SBRP after merging this PR.