### PR TITLE
Fix scenario-tests invocation in the VMR with a live built SDK

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.Common/Program.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/Program.cs
@@ -186,6 +186,13 @@ namespace ScenarioTests
             Console.WriteLine($"  Portable RID: {portableRid}");
             Console.WriteLine($"  Sdk Version: {sdkVersion ?? "latest"}");
             Console.WriteLine($"  Platform: {platform}");
+
+            string? restoreConfigFile = Environment.GetEnvironmentVariable("RestoreConfigFile");
+            if (!string.IsNullOrWhiteSpace(restoreConfigFile))
+            {
+                Console.WriteLine($"  RestoreConfigFile: {restoreConfigFile}");
+            }
+
             if (binlogDir is not null)
             {
                 Console.WriteLine($"  Binlog Directory: {binlogDir}");

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
@@ -65,9 +65,9 @@ internal class DotNetSdkHelper
         process.StartInfo.WorkingDirectory = workingDirectory;
 
         // The `dotnet test` execution context sets a number of dotnet related ENVs that cause issues when executing
-        // dotnet commands.  Clear these to avoid side effects.
-
-        foreach (string key in process.StartInfo.Environment.Keys.Where(key => key.StartsWith("DOTNET_")).ToList())
+        // dotnet commands. Same for MSBuild which adds env vars when invoking the runner via the Exec task.
+        // Clear these to avoid side effects.
+        foreach (string key in process.StartInfo.Environment.Keys.Where(key => key.StartsWith("DOTNET_", StringComparison.OrdinalIgnoreCase) || key.StartsWith("MSBUILD", StringComparison.OrdinalIgnoreCase)).ToArray())
         {
             process.StartInfo.Environment.Remove(key);
         }


### PR DESCRIPTION
MSBuild Exec's task invocation flows a few env vars down that cause issues when running scenario-test swith a live built SDK. I.e. the `MSBuildSDKsPath` env var which would point to the old SDK.

Ignore those env vars and also log the RestoreConfigFile env var if it is set.