### PR TITLE
Add RequiresNonTargetRidPackages trait category

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTests.cs
@@ -204,6 +204,7 @@ public class SdkTemplateTests : IClassFixture<ScenarioTestFixture>
     }
 
     [Theory]
+    [Trait("Category", "RequiresNonTargetRidPackages")]
     [InlineData(DotNetLanguage.CSharp)]
     public void VerifyBlazorWasmTemplate(DotNetLanguage language)
     {


### PR DESCRIPTION
This allows disabling tests that only work after the full join in the VMR, e.g. windows-x64 publishing for browser-wasm