### PR TITLE
Remove System.CommandLine as dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,10 +4,6 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.25202.102">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>49f46ce3082f22cd016b9fffdae880a09b04afcd</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25202.102">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>49f46ce3082f22cd016b9fffdae880a09b04afcd</Sha>


### PR DESCRIPTION
Removing this dependency because it causes issues when using source build with OfficialBuildId: https://github.com/dotnet/sdk/pull/48327. The dependency causes the System.CommandLine version to get lifted to the live version but that version isn't available to restore when building the scenario tests by itself in a separate job.