### PR TITLE
Remove auditSources from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,9 +8,5 @@
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
   </packageSources>
-  <auditSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </auditSources>
   <disabledPackageSources />
 </configuration>


### PR DESCRIPTION
The api.nuget.org source will clash with the CFSClean network isolation policy and the same data is provided by AzDO now.
