### PR TITLE
Simplify azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,6 @@ pr: none
 
 variables:
   - template: /eng/common/templates-official/variables/pool-providers.yml@self
-  - name: _TeamName
-    value: .NETCore
 
 resources:
   repositories:
@@ -29,11 +27,6 @@ extends:
       name: $(DncEngInternalBuildPool)
       image: 1es-windows-2022
       os: windows
-    sdl:
-      policheck:
-        enabled: true
-      tsa:
-        enabled: true
 
     stages:
     - stage: build


### PR DESCRIPTION
policheck and tsa happens in the VMR so we don't need to set it here anymore
_TeamName is just for Microbuild signing so that's also not needed anymore.