### PR TITLE
Add dotnet test coverage scenarios for MSTest (VSTest and MTP)

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
@@ -310,9 +310,10 @@ internal partial class DotNetSdkHelper
         if (useMicrosoftTestingPlatform)
         {
             // On the .NET 10+ SDK the VSTest bridge was removed from Microsoft.Testing.Platform, so
-            // `dotnet test` has to run in its dedicated MTP mode. That mode is opted into via global.json.
-            EnableTestingPlatformRunner(projectDirectory);
-
+            // `dotnet test` has to run in its dedicated MTP mode. That mode is opted into via a global.json
+            // that EnableTestingPlatformRunner writes before `dotnet new` (see its remarks for why the
+            // ordering matters).
+            //
             // MTP mode uses --coverage (Microsoft.Testing.Extensions.CodeCoverage) rather than the VSTest
             // --collect data collector. Unknown switches are forwarded to the test app, so only MTP options
             // are passed here (notably no --nologo, which the app rejects with "Zero tests ran").
@@ -360,11 +361,18 @@ internal partial class DotNetSdkHelper
     }
 
     /// <summary>
-    /// Opts the project into the Microsoft.Testing.Platform mode of <c>dotnet test</c> by merging
-    /// <c>"test": { "runner": "Microsoft.Testing.Platform" }</c> into any existing global.json. Merging
-    /// preserves an SDK version pin that <see cref="ExecuteCmd"/> may already have written.
+    /// Opts a generated project into the Microsoft.Testing.Platform mode of <c>dotnet test</c> by merging
+    /// <c>"test": { "runner": "Microsoft.Testing.Platform" }</c> into a global.json in the project directory,
+    /// preserving any keys already present (for example an SDK version pin).
     /// </summary>
-    private static void EnableTestingPlatformRunner(string projectDirectory)
+    /// <remarks>
+    /// This MUST be called before <c>dotnet new ... --test-runner Microsoft.Testing.Platform</c>. That
+    /// template switch opts in by <em>modifying the nearest global.json</em> it finds walking up from the
+    /// output directory. With no local global.json it rewrites the repo-root one that every generated test
+    /// project shares, which forces the sibling VSTest template tests into MTP mode and breaks them. Writing
+    /// the local file first keeps the template's modification scoped to this project.
+    /// </remarks>
+    public static void EnableTestingPlatformRunner(string projectDirectory)
     {
         string globalJsonPath = Path.Combine(projectDirectory, "global.json");
         JsonObject root = File.Exists(globalJsonPath)

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
@@ -5,6 +5,8 @@
 using Microsoft.DotNet.ScenarioTests.Common;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using System.Xml.XPath;
 using System.Xml;
@@ -295,6 +297,83 @@ internal partial class DotNetSdkHelper
 
     public void ExecuteTest(string projectDirectory) =>
         ExecuteCmd($"test {GetBinLogOption(projectDirectory, "test")}", workingDirectory: projectDirectory);
+
+    /// <summary>
+    /// Runs <c>dotnet test</c> for a generated project while collecting code coverage, then verifies a
+    /// coverage artifact was produced. Supports both the VSTest runner and Microsoft.Testing.Platform (MTP).
+    /// </summary>
+    public void ExecuteTestWithCoverage(string projectDirectory, bool useMicrosoftTestingPlatform)
+    {
+        string resultsDirectory = Path.Combine(projectDirectory, "TestResults");
+
+        string coverageArgs;
+        if (useMicrosoftTestingPlatform)
+        {
+            // On the .NET 10+ SDK the VSTest bridge was removed from Microsoft.Testing.Platform, so
+            // `dotnet test` has to run in its dedicated MTP mode. That mode is opted into via global.json.
+            EnableTestingPlatformRunner(projectDirectory);
+
+            // MTP mode uses --coverage (Microsoft.Testing.Extensions.CodeCoverage) rather than the VSTest
+            // --collect data collector. Unknown switches are forwarded to the test app, so only MTP options
+            // are passed here (notably no --nologo, which the app rejects with "Zero tests ran").
+            coverageArgs = "--coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml";
+        }
+        else
+        {
+            coverageArgs = "--collect \"Code Coverage\"";
+        }
+
+        ExecuteCmd(
+            $"test {coverageArgs} --results-directory \"{resultsDirectory}\" {GetBinLogOption(projectDirectory, "test")}",
+            workingDirectory: projectDirectory);
+
+        IReadOnlyList<string> coverageFiles = FindCoverageFiles(resultsDirectory);
+        if (coverageFiles.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Expected a code coverage artifact under '{resultsDirectory}' but none was produced.");
+        }
+
+        foreach (string coverageFile in coverageFiles)
+        {
+            if (new FileInfo(coverageFile).Length == 0)
+            {
+                throw new InvalidOperationException($"Code coverage artifact was empty: '{coverageFile}'.");
+            }
+
+            _outputHelper.WriteLine($"Produced code coverage artifact: {coverageFile}");
+        }
+    }
+
+    private static IReadOnlyList<string> FindCoverageFiles(string resultsDirectory)
+    {
+        if (!Directory.Exists(resultsDirectory))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateFiles(resultsDirectory, "*", SearchOption.AllDirectories)
+            .Where(file =>
+                file.EndsWith(".coverage", StringComparison.OrdinalIgnoreCase) ||
+                file.EndsWith(".cobertura.xml", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Opts the project into the Microsoft.Testing.Platform mode of <c>dotnet test</c> by merging
+    /// <c>"test": { "runner": "Microsoft.Testing.Platform" }</c> into any existing global.json. Merging
+    /// preserves an SDK version pin that <see cref="ExecuteCmd"/> may already have written.
+    /// </summary>
+    private static void EnableTestingPlatformRunner(string projectDirectory)
+    {
+        string globalJsonPath = Path.Combine(projectDirectory, "global.json");
+        JsonObject root = File.Exists(globalJsonPath)
+            ? JsonNode.Parse(File.ReadAllText(globalJsonPath)) as JsonObject ?? new JsonObject()
+            : new JsonObject();
+
+        root["test"] = new JsonObject { ["runner"] = "Microsoft.Testing.Platform" };
+        File.WriteAllText(globalJsonPath, root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
 
     private string GetBinLogOption(string projectDirectory, string command, string? differentiator = null)
     {

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetTestScenarioTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetTestScenarioTests.cs
@@ -62,6 +62,15 @@ public class DotNetTestScenarioTests : IClassFixture<ScenarioTestFixture>
 
         Directory.CreateDirectory(projectDirectory);
 
+        if (useMicrosoftTestingPlatform)
+        {
+            // Anchor a local global.json before generating. The mstest template's
+            // --test-runner Microsoft.Testing.Platform switch opts in by modifying the nearest global.json
+            // it finds; without a local one it rewrites the shared repo-root global.json and breaks every
+            // other generated test project. See DotNetSdkHelper.EnableTestingPlatformRunner.
+            DotNetSdkHelper.EnableTestingPlatformRunner(projectDirectory);
+        }
+
         // Generate a coherent MSTest project via the template's first-class switches (no csproj hand-editing):
         //   --test-runner selects VSTest vs Microsoft.Testing.Platform,
         //   --coverage-tool pins Microsoft.CodeCoverage so both runners collect coverage,

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetTestScenarioTests.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetTestScenarioTests.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.ScenarioTests.Common;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.ScenarioTests.SdkTemplateTests;
+
+/// <summary>
+/// Exercises <c>dotnet test</c> end-to-end for MSTest projects while collecting code coverage, across both
+/// supported test runners (VSTest and Microsoft.Testing.Platform) and both a current .NET target and .NET
+/// Framework (net48). Each scenario generates a project with <c>dotnet new mstest</c>, runs the tests, and
+/// asserts a coverage artifact was produced.
+///
+/// The .NET Framework legs only run on Windows because net48 test apps cannot execute on Linux/macOS; they
+/// are gated with <c>SkipIfPlatform</c> traits (enforced by the harness in Program.cs).
+/// </summary>
+public class DotNetTestScenarioTests : IClassFixture<ScenarioTestFixture>
+{
+    private const string NetFrameworkTargetFramework = "net48";
+
+    private readonly ScenarioTestFixture _scenarioTestInput;
+    private readonly DotNetSdkHelper _sdkHelper;
+
+    public DotNetTestScenarioTests(ScenarioTestFixture testInput, ITestOutputHelper outputHelper)
+    {
+        if (string.IsNullOrEmpty(testInput.DotNetRoot))
+        {
+            throw new ArgumentException("sdk root must be set for sdk tests");
+        }
+
+        _scenarioTestInput = testInput;
+        _sdkHelper = new DotNetSdkHelper(outputHelper, _scenarioTestInput.DotNetRoot, _scenarioTestInput.SdkVersion, _scenarioTestInput.BinlogDir);
+    }
+
+    [Fact]
+    public void VerifyMSTestVSTestWithCoverage() =>
+        RunMSTestCoverageScenario("VSTest", targetFramework: null, useMicrosoftTestingPlatform: false);
+
+    [Fact]
+    [Trait("SkipIfPlatform", "LINUX")]
+    [Trait("SkipIfPlatform", "OSX")]
+    public void VerifyMSTestVSTestNetFrameworkWithCoverage() =>
+        RunMSTestCoverageScenario("VSTestNetFx", targetFramework: NetFrameworkTargetFramework, useMicrosoftTestingPlatform: false);
+
+    [Fact]
+    public void VerifyMSTestMtpWithCoverage() =>
+        RunMSTestCoverageScenario("Mtp", targetFramework: null, useMicrosoftTestingPlatform: true);
+
+    [Fact]
+    [Trait("SkipIfPlatform", "LINUX")]
+    [Trait("SkipIfPlatform", "OSX")]
+    public void VerifyMSTestMtpNetFrameworkWithCoverage() =>
+        RunMSTestCoverageScenario("MtpNetFx", targetFramework: NetFrameworkTargetFramework, useMicrosoftTestingPlatform: true);
+
+    private void RunMSTestCoverageScenario(string scenario, string? targetFramework, bool useMicrosoftTestingPlatform)
+    {
+        string projectName = $"{nameof(DotNetTestScenarioTests)}_{scenario}";
+        string projectDirectory = Path.Combine(_scenarioTestInput.TestRoot, projectName);
+
+        Directory.CreateDirectory(projectDirectory);
+
+        // Generate a coherent MSTest project via the template's first-class switches (no csproj hand-editing):
+        //   --test-runner selects VSTest vs Microsoft.Testing.Platform,
+        //   --coverage-tool pins Microsoft.CodeCoverage so both runners collect coverage,
+        //   --framework (when set) targets .NET Framework instead of the SDK's default TFM.
+        string testRunner = useMicrosoftTestingPlatform ? "Microsoft.Testing.Platform" : "VSTest";
+        string customArgs = $"--test-runner {testRunner} --coverage-tool Microsoft.CodeCoverage";
+        if (!string.IsNullOrEmpty(targetFramework))
+        {
+            customArgs += $" --framework {targetFramework}";
+        }
+
+        _sdkHelper.ExecuteNew(DotNetSdkTemplate.MSTest.GetName(), projectName, projectDirectory, customArgs: customArgs);
+
+        _sdkHelper.ExecuteTestWithCoverage(projectDirectory, useMicrosoftTestingPlatform);
+    }
+}


### PR DESCRIPTION
The template tests already run `dotnet test`, but only with the default runner, one .NET target, and no coverage. This adds four MSTest scenarios that also collect coverage, so we exercise the SDK coverage pipeline across both runners and both target types in one go:

| Runner | Target | Runs on |
|---|---|---|
| VSTest | current .NET | all platforms |
| VSTest | .NET Framework (net48) | Windows only |
| Microsoft.Testing.Platform | current .NET | all platforms |
| Microsoft.Testing.Platform | .NET Framework (net48) | Windows only |

Projects are generated with `dotnet new mstest` and its switches (`--test-runner`, `--coverage-tool`, `--framework`), so there is no csproj editing. Each test asserts a non-empty coverage artifact was produced (`*.coverage` for VSTest, `coverage.cobertura.xml` for MTP).

The net48 legs only run on Windows, because net48 test apps cannot run on Linux or macOS, so they carry `SkipIfPlatform` LINUX and OSX traits. MTP mode is opted into with a `test.runner` entry in global.json, because the VSTest bridge was removed in Microsoft.Testing.Platform 2.x. The helper merges that entry into any existing global.json so an SDK version pin is preserved.

Verified locally on Windows against the repo .NET 11 preview SDK: all 4 pass in about 34s with cold restore included, and a coverage artifact is produced for each. Build is clean with `TreatWarningsAsErrors` on.
