### PR TITLE
Add hang timeouts to dotnet test coverage scenarios

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
@@ -306,6 +306,20 @@ internal partial class DotNetSdkHelper
     {
         string resultsDirectory = Path.Combine(projectDirectory, "TestResults");
 
+        // A hung `dotnet test` here used to run until the CI job's outer task timeout (30 min) hard-killed
+        // the whole process tree. That produced no dump and left the scenario binlog unfinalized, so the
+        // hang surfaced only as a silent task timeout with nothing to debug. Guard against it with two
+        // layered timeouts, both comfortably below the outer task timeout so one of them always fires first:
+        //   1. hangDumpTimeout - the test runner detects the hang and captures a dump of the stuck test host
+        //      (and a sequence file naming the in-flight test) into the results directory before it
+        //      self-terminates. Wired up for VSTest via --blame-hang below; the MTP path needs the
+        //      Microsoft.Testing.Extensions.HangDump package and is tracked as a follow-up.
+        //   2. executionTimeout - a runner-agnostic backstop in ExecuteHelper.ExecuteProcess that kills the
+        //      process tree and fails this scenario with an attributed timeout message if the runner's own
+        //      hang handling never kicks in (for example the MTP path today).
+        TimeSpan hangDumpTimeout = TimeSpan.FromMinutes(10);
+        TimeSpan executionTimeout = TimeSpan.FromMinutes(15);
+
         string coverageArgs;
         if (useMicrosoftTestingPlatform)
         {
@@ -316,17 +330,26 @@ internal partial class DotNetSdkHelper
             //
             // MTP mode uses --coverage (Microsoft.Testing.Extensions.CodeCoverage) rather than the VSTest
             // --collect data collector. Unknown switches are forwarded to the test app, so only MTP options
-            // are passed here (notably no --nologo, which the app rejects with "Zero tests ran").
+            // are passed here (notably no --nologo, which the app rejects with "Zero tests ran"). A native
+            // MTP hang dump (--hangdump) would need the Microsoft.Testing.Extensions.HangDump package to be
+            // referenced by the generated project; until then this path relies on executionTimeout below.
             coverageArgs = "--coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml";
         }
         else
         {
-            coverageArgs = "--collect \"Code Coverage\"";
+            // --collect "Code Coverage" runs under VSTest. --blame-hang makes the VSTest host self-monitor
+            // and, if a test exceeds the timeout, write a full hang dump plus a Sequence.xml naming the
+            // in-flight test into --results-directory before aborting -- so an intermittent hang leaves a
+            // diagnosable artifact instead of a silent kill.
+            coverageArgs =
+                $"--collect \"Code Coverage\" --blame-hang --blame-hang-timeout {(int)hangDumpTimeout.TotalMinutes}m " +
+                "--blame-hang-dump-type full";
         }
 
         ExecuteCmd(
             $"test {coverageArgs} --results-directory \"{resultsDirectory}\" {GetBinLogOption(projectDirectory, "test")}",
-            workingDirectory: projectDirectory);
+            workingDirectory: projectDirectory,
+            millisecondTimeout: (int)executionTimeout.TotalMilliseconds);
 
         IReadOnlyList<string> coverageFiles = FindCoverageFiles(resultsDirectory);
         if (coverageFiles.Count == 0)


### PR DESCRIPTION
When a coverage scenario's `dotnet test` hangs, nothing stops it until the CI job's outer task timeout (30 min) hard-kills the whole process tree. The kill produces no dump and leaves the scenario binlog unfinalized, so the hang shows up only as a silent task timeout with nothing to debug. This already hit the Windows_x64 leg of the unified build in build 3023050, where the MtpNetFx scenario hung and the leg was killed at 29:57, then passed on retry.

## Changes

Two layered timeouts in `ExecuteTestWithCoverage`, both below the outer task timeout so one of them always fires first:

- VSTest: `--blame-hang --blame-hang-timeout 10m --blame-hang-dump-type full`, so the test host writes a full hang dump and a Sequence.xml naming the in-flight test into `--results-directory` before it aborts.
- A runner-agnostic backstop (15 min) via `ExecuteHelper.ExecuteProcess`, which kills the process tree and fails the scenario with an attributed timeout message if the runner's own hang handling never fires.

## Verification

`build.cmd` passes locally. The scenario pipeline exercises the coverage legs end to end.

Note: the MTP path does not get a native hang dump yet, that needs the `Microsoft.Testing.Extensions.HangDump` package on the generated project, which touches the offline source-built feed and deserves its own change. Until then MTP relies on the backstop, which turns the silent 30 min kill into a fast failure attributed to the specific scenario.
