### PR TITLE
Bound post-kill WaitForExit to prevent scenario-test hangs

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.Common/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/ExecuteHelper.cs
@@ -10,6 +10,13 @@ namespace Microsoft.DotNet.ScenarioTests.Common;
 
 public static class ExecuteHelper
 {
+    // Grace period to wait for a killed process tree to fully exit. A parameterless
+    // WaitForExit() after Kill(true) blocks until the redirected stdout/stderr pipes
+    // reach EOF; a surviving grandchild (e.g. the web app spawned by `dotnet run`) that
+    // inherited those handles can keep them open indefinitely, hanging the test until the
+    // pipeline task timeout. Bounding the wait lets the run fail fast instead.
+    public const int KillGraceMilliseconds = 30_000;
+
     public static (Process Process, string StdOut, string StdErr) ExecuteProcess(
         string fileName,
         string args,
@@ -63,7 +70,11 @@ public static class ExecuteHelper
         {
             outputHelper.WriteLine($"Killing: {fileName} {args}");
             process.Kill(true);
-            process.WaitForExit();
+            if (!process.WaitForExit(KillGraceMilliseconds))
+            {
+                outputHelper.WriteLine("Process tree did not fully exit within the kill grace period; " +
+                    "abandoning wait to avoid hanging on inherited stdout/stderr handles.");
+            }
             ProcessStartInfo startInfo = process.StartInfo;
             string msg = $" {startInfo.FileName} {startInfo.Arguments} timed out after " +
                 $"{millisecondTimeout} milliseconds" +

--- a/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
@@ -238,7 +238,7 @@ internal partial class DotNetSdkHelper
                 if (e.Data?.Contains("Application started. Press Ctrl+C to shut down.") ?? false)
                 {
                     process.Kill(true);
-                    process.WaitForExit();
+                    process.WaitForExit(ExecuteHelper.KillGraceMilliseconds);
                 }
             });
         }
@@ -276,7 +276,7 @@ internal partial class DotNetSdkHelper
                 await Task.Delay(5000);
             }
             TerminateProcess(process.Handle, 0);
-            process.WaitForExit();
+            process.WaitForExit(ExecuteHelper.KillGraceMilliseconds);
         }
 
         bool checkProcess(string projectDirectory, Process process)


### PR DESCRIPTION
## Problem

The scenario-test harness intermittently hangs a test leg until the pipeline task timeout (observed as a **4h hang producing no `.trx`**). It shows up most on the newest distro image in the source-build offline validation matrix — `SB_Fedora43_Offline_PreviousSourceBuiltSdk_Validation_x64` — and a retry sometimes passes, so it's a race, not a deterministic failure. Tracked in **dotnet/source-build#5624**.

## Root cause

Every process-teardown path kills a long-running process (e.g. `dotnet run` on a web template) with `Kill(true)` and then calls the **parameterless** `WaitForExit()`:

```csharp
process.Kill(true);
process.WaitForExit();   // blocks until stdout/stderr pipes hit EOF
```

Because stdout/stderr are redirected and read asynchronously (`BeginOutputReadLine`), `WaitForExit()` waits for the async readers to reach **EOF on the pipes**, not merely for the process to exit. `dotnet run` launches the app as a child/grandchild that inherits those pipe write handles. `Kill(true)` signals the process tree known at that instant, but if a descendant survives the kill for a moment (tree-walk race / reparent to pid 1), it keeps the write end open, EOF never arrives, and `WaitForExit()` blocks **forever**. Newer Fedora 43 (kernel + systemd + cgroup v2 reaping differences) makes the lingering-child race most likely, and the offline `PreviousSourceBuiltSdk` legs hit the timeout→kill path most often.

## Fix

Bound every post-kill wait with a grace timeout (`ExecuteHelper.KillGraceMilliseconds = 30_000`) so the run fails fast instead of hanging. On the already-failing/timeout path, accepting possibly-truncated output is fine. Three sites:

- `Microsoft.DotNet.ScenarioTests.Common/ExecuteHelper.cs` — `ExecuteProcess`
- `Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs` — `ExecuteRunWeb` and `ExecuteRunUIApp`

Minimal, behavior-preserving for the healthy path; only the pathological "won't die / pipe held open" case changes (from infinite hang to fast failure). Built locally with `build.cmd` (0 warnings, 0 errors).

> Note: the VMR carries a sibling copy at `test/TestUtilities/ExecuteHelper.cs` (dotnet/dotnet) with the identical pattern; that one should get the same bound separately.

## Investigation

Full analysis and signals: https://github.com/dotnet/source-build/issues/5624

cc @akoeplinger @ViktorHofer — you're the most active maintainers here; would appreciate a review.
