### PR TITLE
Synchronize redirected output snapshots

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.Common/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/ExecuteHelper.cs
@@ -82,13 +82,21 @@ public static class ExecuteHelper
             throw new InvalidOperationException(msg);
         }
 
-        string output = stdOutput.ToString().Trim();
+        string output;
+        lock (stdOutput)
+        {
+            output = stdOutput.ToString().Trim();
+        }
         if (logOutput && !string.IsNullOrWhiteSpace(output))
         {
             outputHelper.WriteLine(output);
         }
 
-        string error = stdError.ToString().Trim();
+        string error;
+        lock (stdError)
+        {
+            error = stdError.ToString().Trim();
+        }
         if (logOutput && !string.IsNullOrWhiteSpace(error))
         {
             outputHelper.WriteLine(error);


### PR DESCRIPTION
## Failure

VMR Azure DevOps build [3039585](https://dev.azure.com/dnceng-public/public/_build/results?buildId=3039585&view=results) had two source-only validation failures:

- `SB_CentOSStream10_Offline_CurrentSourceBuiltSdk_Validation_x64`
- `SB_Alpine323_Offline_MsftSdk_Validation_x64`

In both legs, `VerifyWebAPITemplate(language: FSharp)` threw `System.ArgumentOutOfRangeException` with parameter `chunkLength` from `StringBuilder.ToString()` while `ExecuteHelper` was collecting redirected process output.

## Suspected cause

PR #354 changed the post-kill process waits in `ExecuteHelper.ExecuteProcess`, `DotNetSdkHelper.ExecuteRunWeb`, and `DotNetSdkHelper.ExecuteRunUIApp` from an unbounded `WaitForExit()` to a 30-second bounded wait. That change prevents scenario-test hangs when a surviving descendant keeps redirected stdout/stderr handles open, but it also allows execution to continue before the asynchronous readers have reached EOF.

The `OutputDataReceived` and `ErrorDataReceived` callbacks append under locks, while the later `StringBuilder.ToString()` snapshots were outside those locks. If a callback runs while a snapshot is being taken, `StringBuilder` can observe concurrent mutation and throw. **Confidence: high.**

## Fix

Take the stdout and stderr snapshots under the same existing locks used by their respective callbacks. This preserves the bounded wait while preventing concurrent reads and writes.