### PR TITLE
[release/10.0] Synchronize redirected output snapshots

### DIFF
--- a/src/Microsoft.DotNet.ScenarioTests.Common/ExecuteHelper.cs
+++ b/src/Microsoft.DotNet.ScenarioTests.Common/ExecuteHelper.cs
@@ -82,13 +82,21 @@ public static class ExecuteHelper
             throw new InvalidOperationException(msg);
         }
 
-        string output = stdOutput.ToString().Trim();
+        string output;
+        lock (stdOutput)
+        {
+            output = stdOutput.ToString().Trim();
+        }
         if (logOutput && !string.IsNullOrWhiteSpace(output))
         {
             outputHelper.WriteLine(output);
         }
 
-        string error = stdError.ToString().Trim();
+        string error;
+        lock (stdError)
+        {
+            error = stdError.ToString().Trim();
+        }
         if (logOutput && !string.IsNullOrWhiteSpace(error))
         {
             outputHelper.WriteLine(error);


### PR DESCRIPTION
Redirected stdout and stderr callbacks can still mutate their `StringBuilder` instances while `ExecuteHelper` takes the final snapshots, causing a race. This backport takes each snapshot under the same lock used by its asynchronous callback.

Backports #359 to `release/10.0`.