### PR TITLE
Remove Publish-Build-Assets variable group from release/9.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,8 +59,6 @@ extends:
               name: $(DncEngInternalBuildPool)
               demands: ImageOverride -equals 1es-windows-2022
             variables:
-            # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-            - group: Publish-Build-Assets
             - name: _OfficialBuildArgs
               value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             strategy:


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `azure-pipelines.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131